### PR TITLE
CoinSort2: migrate to coin-collections API + diameter scaling fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import Stories from 'src/pages/Stories/Stories.js';
 import StoryReader from 'src/pages/Stories/StoryReader.js';
 import ExploreTheEvidence from 'src/pages/Evidence/ExploreTheEvidence.js';
 import CoinSort from 'src/pages/Evidence/CoinSort/CoinSort.js';
+import CoinSort2 from 'src/pages/Evidence/CoinSort/CoinSort2.js';
 import MapCoins from './pages/Evidence/MapCoins/MapCoins';
 import CoinCatalog from './pages/Evidence/CoinCatalogy/CoinCatalog';
 import Coins from './pages/Evidence/CoinCatalogy/CoinList/Coins';
@@ -119,7 +120,7 @@ return (
 			<NavDropdown title='EVIDENCE' className='navbar-text'>
 				<NavDropdown.Item as={Link} to='/Evidence' className='navbar-text '>Overview</NavDropdown.Item>
 				<NavDropdown.Divider />
-				<NavDropdown.Item as={Link} to='/Evidence/CoinSort' className='navbar-text'>Coins in a Pile</NavDropdown.Item>
+				<NavDropdown.Item as={Link} to='/Evidence/CoinSort2' className='navbar-text'>Coins in a Pile</NavDropdown.Item>
 				<NavDropdown.Item as={Link} to='/Evidence/MapCoins' className='navbar-text'>Coins on a Map</NavDropdown.Item>
 				<NavDropdown.Item as={Link} to='/Evidence/Timeline' className='navbar-text'>Coins in Time</NavDropdown.Item>
 				<NavDropdown.Item as={Link} to='/Evidence/CoinCatalog' className='navbar-text'>Coins in a Catalog</NavDropdown.Item>
@@ -145,7 +146,7 @@ return (
 				<Route path='/Stories' element={<Stories />} />
 				<Route path='/Evidence' element={<ExploreTheEvidence />} /> 
 				<Route path='/Toolbox' element={<Toolbox />} />
-				<Route path='/Evidence/CoinSort' element={<CoinSort />} />
+				<Route path='/Evidence/CoinSort2' element={<CoinSort2 />} />				
 				<Route path='/Evidence/MapCoins' element={<MapCoins />} />
 				<Route path='/Evidence/Timeline' element={<Timeline />} />
 				<Route path='/Evidence/CoinCatalog' element={<CoinCatalog />} />

--- a/src/api/coin-collections.js
+++ b/src/api/coin-collections.js
@@ -1,75 +1,38 @@
 import axios from "axios";
-import qs from 'qs';
+import qs from "qs";
 
-const coinCollections = {
-    coinCollectionPage:()=>{
-        let query = qs.stringify({
-            populate: [
-                'contents',
-                'coin_of_the_day',
-                'coin_of_the_day.image',
-                'spotlight',
-                'spotlight.obverse_image',
-                'spotlight.reverse_image',
-                'spotlight.denomination',
-                'spotlight.ancient_territory',
-                'spotlight.mint.modern_name',
-                'spotlight.mint.modern_country',
-                'spotlight.governing_power',
-                'spotlight.issuing_authority',
-            ],
-            pagination: {page: 1,pageSize: 2147483647}
-        },{encodeValuesOnly: true});
-        return axios(`${process.env.REACT_APP_API_URL}/coin-collection-page?${query}`,{
-            method:'GET',
-        })
-    },
+const coinCollectionsRequest = {
+  // Equivalent of “all coins used by CoinSort”
+  fetchAllForCoinSort: () => {
+    const query = qs.stringify(
+      {
+        filters: {
+          appear_catalog_pile: true, // same idea as your earlier filter
+        },
+        populate: {
+          obverse_image: true,
+          reverse_image: true,
+          mint: true,
+          material: true,
+          denomination: true,
+          issuing_authority: true,
+          governing_power: true,
+          ancient_territory: true,
+          type_categories: true,
+          language: true,
+        },
+        pagination: { page: 1, pageSize: 2147483647 },
+      },
+      { encodeValuesOnly: true }
+    );
 
-    coinCollection:()=>{
-        let query = qs.stringify({
-            filters:{
-                appear_catalog_pile:true,
-            },
-            populate: [
-                'obverse_image','reverse_image',
-                'denomination',
-                'ancient_territory',
-                'mint.modern_name',
-                'mint.modern_country',
-                'governing_power',
-                'issuing_authority',
-                'material',
-                'language'
-            ],
-            pagination: {page: 1,pageSize: 2147483647}
-            // pagination: {page: 1,pageSize: 96}
+    return axios.get(`${process.env.REACT_APP_strapiURL}/api/coin-collections?${query}`);
+  },
 
-        },{encodeValuesOnly: true});
-        return axios(`${process.env.REACT_APP_API_URL}/coin-collections?${query}`,{
-            method:'GET',
-        })
-    },
-    coinSearch:()=>{
-        let query = qs.stringify({
-            filters:{
-                appear_catalog_pile:true,
-            },
-            populate: [
-                'obverse_image','reverse_image','denomination',
-                'ancient_territory',
-                'mint.modern_name',
-                'mint.modern_country',
-                'governing_power',
-                'issuing_authority',
-                'material',
-                'language'
-            ],
-            pagination: {page: 1,pageSize: 2147483647}
-        },{encodeValuesOnly: true});
-        return axios(`${process.env.REACT_APP_API_URL}/coin-collections?${query}`,{
-            method:'GET',
-        })
-    },
+  fetchCoinSortConfig: () => {
+    // keep using what you already have, unless you want a new config entry
+    return axios.get(`${process.env.REACT_APP_strapiURL}/api/coin-sort?populate=*`);
+  },
+};
 
-}
-export default coinCollections
+export default coinCollectionsRequest;

--- a/src/pages/Evidence/CoinSort/CoinSort.js
+++ b/src/pages/Evidence/CoinSort/CoinSort.js
@@ -31,6 +31,9 @@ const filter_selections_query_relation = [null, true, false];
 const with_selections = ['None', 'Minting Date', 'Material', 'Issuing Authority', 'Governing Power', 'Size'];
 // const with_selections_query_relation = ['', 'from_date', 'material', 'issuing_authority', 'governing_power.data.attributes.governing_power', 'diameter'];
 const of_kind_no_selections = ['None'];
+// degToRad helper
+const degToRad = (deg) => (deg * Math.PI) / 180;
+
 
 // const of_kind_from_date_selections = [
 // 'None',
@@ -84,6 +87,8 @@ const of_kind_from_date_query_relation = [
   {gte: -400, lte: -301},
   {gte: -300, lte: -201},
   {gte: -200, lte: -101},
+  // gte: -100 to lte: -1 is 100 B.C.E to 1 B.C.E, it was missing
+  { gte: -100, lte: -1 },
   {gte: 1, lte: 99},
   {gte: 100, lte: 199},
   {gte: 200, lte: 299},
@@ -92,12 +97,21 @@ const of_kind_from_date_query_relation = [
 ];
 const of_kind_material_selections = ['None','Gold','Silver','Bronze','Orichalcum','Uncertain'];
 const of_kind_issuing_authority_selections = ['None','Royal','Imperial','Provincial','Civic','Uncertain',];
+
+/*
 const of_kind_governing_power_selections = [];
 (async () => {
   const { data } = await axios.get(`${process.env.REACT_APP_strapiURL}/api/governing-powers`);
   let arr = data.data.map(({ attributes }) => attributes.governing_power);
   of_kind_governing_power_selections.push('None', ...arr);
 })();
+
+// this shouldn't be here. it's running on every hot reload, sometimes multiple times
+// it's not tied to component lifecycle
+// dropdown may render data before it arrives and never forces a re-render when the array mutates
+// mutation based push into array is not react friendly
+*/
+
 const of_kind_size_selections = [
   'None',
   '1mm - 10mm',
@@ -171,7 +185,7 @@ const Coin = (props) => {
 // The first this it does is setup default positioning. This is so coins_pos is insured to be defined for filtration.
 // The next thing done is sorting the coins into different piles. 
 // The last thing done is filtering the coins based on the coin sort options
-function ComputeCoinPos(coins, sort_selection, then_by_selection, filter_selection, with_selection, of_kind_selection) {
+function ComputeCoinPos(coins, sort_selection, then_by_selection, filter_selection, with_selection, of_kind_selection, governingPowers) {
   if (!Array.isArray(coins)) return null;
 
   // perform default positioning
@@ -210,7 +224,7 @@ function ComputeCoinPos(coins, sort_selection, then_by_selection, filter_selecti
         break;
       case sort_selections[4]: // Governing Power
         key = 'governing_power';
-        query_selection = of_kind_governing_power_selections;
+        query_selection = governingPowers ?? ['None'];
         is_match_type = true;
         break;
       case sort_selections[5]: // Size
@@ -265,7 +279,8 @@ function ComputeCoinPos(coins, sort_selection, then_by_selection, filter_selecti
           break;
         case then_by_selections[4]: // Governing Power
           key = 'governing_power';
-          query_selection = of_kind_governing_power_selections;
+          //query_selection = of_kind_governing_power_selections;
+          query_selection = governingPowers ?? ['None'];
           is_match_type = true;
           break;
         case then_by_selections[5]: // Size
@@ -303,8 +318,14 @@ function ComputeCoinPos(coins, sort_selection, then_by_selection, filter_selecti
         let degrees_between_pile = 360 / then_by_new_coin_piles.length;
         for (let j = 0; j < then_by_new_coin_piles.length; j++) {
           new_pile_locations.push({
-            x: distance_from_center * Math.cos(degrees_between_pile * j) + center.x,
-            y: distance_from_center * Math.sin(degrees_between_pile * j) + center.y,
+            /*
+              x: distance_from_center * Math.cos(degrees_between_pile * j) + center.x,
+              y: distance_from_center * Math.sin(degrees_between_pile * j) + center.y,
+            */
+           // fixed pile offsets. math.cos and .sin expect radians
+           x: distance_from_center * Math.cos(degToRad(degrees_between_pile * j)) + center.x,
+           y: distance_from_center * Math.sin(degToRad(degrees_between_pile * j)) + center.y,
+           
           });
         }
 
@@ -374,7 +395,14 @@ function ComputeCoinPos(coins, sort_selection, then_by_selection, filter_selecti
           if (query == null) {
             does_include = coin[coin_key]?.toLowerCase()?.includes(of_kind_selection.toLowerCase()) ?? filter_include;
           } else {
-            does_include = coin[coin_key] >= query.gte && coin[coin_key] <= query.gte;
+            // i think this is a bug.
+            // <= should be query.lte
+            //does_include = coin[coin_key] >= query.gte && coin[coin_key] <= query.gte;
+            // that logic was creating an empty filter
+            // so if gte = -500, it's value >= -500 && value <= -500
+            // which is only true if value = -500
+            // changing to lte fixes it and provides the correct range filtering
+            does_include = coin[coin_key] >= query.gte && coin[coin_key] <= query.lte;
           }
         } catch (err) {}
 
@@ -407,11 +435,13 @@ const CoinPile = (props) => {
         props.thenBySelection, 
         props.filterSelection, 
         props.withSelection, 
-        props.ofKindSelection
+        props.ofKindSelection,
+        props.governingPowers
       )
     );
-  }, [props.coins, props.sortSelection, props.thenBySelection, props.filterSelection, props.withSelection, props.ofKindSelection]);
+  }, [props.coins, props.sortSelection, props.thenBySelection, props.filterSelection, props.withSelection, props.ofKindSelection, props.governingPowers]);
 
+  /*
   // Update dimensions on screen resize. Very expensive, so setting dimensions only once is better
   const [dimensions, set_dimensions] = useState({width: 0, height: 0});
   useEffect(() => {
@@ -425,6 +455,40 @@ const CoinPile = (props) => {
   useEffect(() => {
     set_dimensions({width: coin_wrapper_ref?.current?.clientWidth ?? 0, height: coin_wrapper_ref?.current?.clientHeight ?? 0});
   }, [coin_wrapper_ref]);
+  */
+
+  // optimized resizer
+  // Track the pixel size of the pile wrapper so we can convert normalized x/y into screen positions.
+  const [dimensions, set_dimensions] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const el = coin_wrapper_ref.current;
+    if (!el) return;
+
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      set_dimensions({
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+      });
+    };
+
+    // Initial measurement
+    update();
+
+    // Observe actual element resizes (more reliable than window "resize")
+    const ro = new ResizeObserver(() => update());
+    ro.observe(el);
+
+    // Optional: also listen to window resize as a cheap fallback
+    window.addEventListener("resize", update);
+
+    return () => {
+      window.removeEventListener("resize", update);
+      ro.disconnect();
+    };
+  }, []);
+
 
   return (
     <div className='coin-sort-pile-wrapper' ref={coin_wrapper_ref}>
@@ -475,6 +539,29 @@ const CoinSort = () => {
   const [of_kind_selection, set_of_kind_selection] = useState(of_kind_no_selections[0]);
   
   const [of_kind_selections, set_of_kind_selections] = useState(of_kind_no_selections);
+  
+    // Governing powers list must be state so React re-renders when it arrives
+  const [governingPowers, setGoverningPowers] = useState(['None']);
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      try {
+        const { data } = await axios.get(`${process.env.REACT_APP_strapiURL}/api/governing-powers`);
+        const arr =
+          data?.data
+            ?.map(({ attributes }) => attributes?.governing_power)
+            .filter(Boolean) ?? [];
+
+        if (mounted) setGoverningPowers(['None', ...arr]);
+      } catch (err) {
+        // keep a safe fallback
+        if (mounted) setGoverningPowers(['None']);
+      }
+    })();
+
+    return () => { mounted = false; };
+  }, []);
 
   // Fetch ALL the coins and ALL their data.
   useEffect(() => {
@@ -509,8 +596,9 @@ const CoinSort = () => {
           set_of_kind_selection(of_kind_issuing_authority_selections[0]);
           return of_kind_issuing_authority_selections;
         case 'Governing Power':
-          set_of_kind_selection(of_kind_governing_power_selections[0]);
-          return of_kind_governing_power_selections;
+          //set_of_kind_selection(of_kind_governing_power_selections[0]);
+          set_of_kind_selection(governingPowers[0] ?? 'None');
+          return governingPowers;
         case 'Size':
           set_of_kind_selection(of_kind_size_selections[0]);
           return of_kind_size_selections;
@@ -519,9 +607,11 @@ const CoinSort = () => {
           return of_kind_no_selections;
       };
     });
-  }, [with_selection]);
+  }, [with_selection, governingPowers]);
+
 
   const [coinSortData, setCoinSortData] = useState([])
+  /*
   useEffect(() => {
     async function fectCoinSortData(){
       let result = await coinSortRequest.coinSortFind()
@@ -530,7 +620,38 @@ const CoinSort = () => {
     }
 
     fectCoinSortData()
-  });
+  });*/
+
+  // prior code runs on every render, causing infinite loop
+  useEffect(() => {
+  // A simple "is this component still mounted?" flag.
+  // We flip this to false in the cleanup function.
+  // Why? If the request finishes after the component unmounts,
+  // calling setState would trigger React warnings and is wasted work.
+  let mounted = true;
+
+    // We run an async function immediately (IIFE) because useEffect
+    // callbacks themselves can't be marked `async`.
+    (async () => {
+      try {
+        // Fetch the CoinSort configuration object from Strapi
+        const result = await coinSortRequest.coinSortFind();
+        // If the component unmounted while we were waiting, do nothing.
+        if (!mounted) return;
+        // Store the returned attributes in state (this triggers a render).
+        setCoinSortData(result.data.data.attributes);
+      } finally {
+        // `finally` runs whether the request succeeds or throws.
+        // We still want to stop showing the loading UI in either case.
+        // (Optionally, you could also set an error state in `catch`.)        
+        if (mounted) set_is_loading(false);
+      }
+    })();
+    // Cleanup function: runs when the component unmounts
+    // (and also before rerunning this effect if deps change).
+    // This prevents setState from firing after unmount.
+    return () => { mounted = false; };
+  }, []);
 
   // Useeffect that listens to changes on then_by_selection, and sort_selection, and displays the clear button if either then_by or sort_by have non-default content 
   const [show_sort_clear_button, set_show_sort_clear_button] = useState(false);
@@ -617,6 +738,7 @@ const CoinSort = () => {
             filterSelection={filter_selection}
             withSelection={with_selection}
             ofKindSelection={of_kind_selection}
+            governingPowers={governingPowers}            
           />
           {/* <div id='coin-sort-title' className='story-h1 text-center'>
             Coins in a Pile

--- a/src/pages/Evidence/CoinSort/CoinSort2.js
+++ b/src/pages/Evidence/CoinSort/CoinSort2.js
@@ -1,0 +1,769 @@
+// src/pages/.../CoinSort2.js
+
+// This is a full refactor of CoinSort that keeps the core UX but replaces the underlying data source with coin-collections
+// last edit: 2026-02-11 by allen martin
+
+import React, { useRef, useEffect, useState } from 'react';
+import axios from 'axios';
+
+import LoadingPage from 'src/components/loadingPage/LoadingPage.js';
+import NoFeedBackIcon from 'src/components/constant/NoFeedBackIcon.js';
+import { CoinGrid } from './CoinSortCoinGrid.js';
+import CoinSortDropDown from './CoinSortDropDown.js';
+
+import {
+  DefaultCoinPileGraphingStategy,
+  GaussianDeviationOnValue,
+  SimplyMappedCoin,
+  CoinPileLocations,
+} from './CoinUtils.js';
+
+import coinCollectionsRequest from 'src/api/coin-collections'; // ✅ new data source
+import coinSortRequest from 'src/api/coin-sort'; // ✅ keep tooltips/config from existing endpoint
+
+// ─────────────────────────────────────────────────────────────
+// Constants / Enumerations (same UX)
+// ─────────────────────────────────────────────────────────────
+const sort_selections = ['None', 'Minting Date', 'Material', 'Issuing Authority', 'Governing Power', 'Size'];
+const then_by_selections = ['None', 'Minting Date', 'Material', 'Issuing Authority', 'Governing Power', 'Size'];
+const filter_selections = ['None', 'Including', 'Excluding'];
+const filter_selections_query_relation = [null, true, false];
+const with_selections = ['None', 'Minting Date', 'Material', 'Issuing Authority', 'Governing Power', 'Size'];
+const of_kind_no_selections = ['None'];
+
+const degToRad = (deg) => (deg * Math.PI) / 180;
+
+const of_kind_from_date_selections = [
+  'None',
+  'before - 500 B.C.E',
+  '500 B.C.E - 401 B.C.E',
+  '400 B.C.E - 301 B.C.E',
+  '300 B.C.E - 201 B.C.E',
+  '200 B.C.E - 101 B.C.E',
+  '100 B.C.E - 1 B.C.E',
+  '1 C.E - 99 C.E',
+  '100 C.E - 199 C.E',
+  '200 C.E - 299 C.E',
+  '300 C.E - 399 C.E',
+  '400 C.E - present',
+];
+
+const of_kind_from_date_query_relation = [
+  { gte: -2147483648, lte: 2147483647 },
+  { gte: -2147483648, lte: -500 },
+  { gte: -500, lte: -401 },
+  { gte: -400, lte: -301 },
+  { gte: -300, lte: -201 },
+  { gte: -200, lte: -101 },
+  { gte: -100, lte: -1 }, // 100 BCE to 1 BCE
+  { gte: 1, lte: 99 },
+  { gte: 100, lte: 199 },
+  { gte: 200, lte: 299 },
+  { gte: 300, lte: 399 },
+  { gte: 400, lte: 2147483647 },
+];
+
+const of_kind_material_selections = ['None', 'Gold', 'Silver', 'Bronze', 'Orichalcum', 'Uncertain'];
+const of_kind_issuing_authority_selections = ['None', 'Royal', 'Imperial', 'Provincial', 'Civic', 'Uncertain'];
+
+const of_kind_size_selections = [
+  'None',
+  '1mm - 10mm',
+  '10mm - 15mm',
+  '15mm - 20mm',
+  '20mm - 25mm',
+  '25mm - 30mm',
+  '30mm - 35mm',
+  '35mm - 40mm',
+  '40mm - 50mm',
+  'Uncertain',
+];
+
+const of_kind_size_query_relation = [
+  { gte: -2147483648, lte: 2147483647 },
+  { gte: 1, lte: 10 },
+  { gte: 10, lte: 15 },
+  { gte: 15, lte: 20 },
+  { gte: 20, lte: 25 },
+  { gte: 25, lte: 30 },
+  { gte: 30, lte: 35 },
+  { gte: 35, lte: 40 },
+  { gte: 40, lte: 50 },
+  { gte: null, lte: null },
+];
+
+// ─────────────────────────────────────────────────────────────
+// Coin-collections → CoinSort-compatible adapter
+// (keeps ComputeCoinPos + CoinGrid working)
+// ─────────────────────────────────────────────────────────────
+const safeRelName = (rel, keys = ['name', 'title', 'label', 'governing_power', 'modern_name']) => {
+  const attrs = rel?.data?.attributes;
+  if (!attrs) return null;
+  for (const k of keys) {
+    if (attrs?.[k]) return attrs[k];
+  }
+  return null;
+};
+
+const safeMediaFormats = (media) => media?.data?.attributes?.formats ?? null;
+const safeMediaAlt = (media) => media?.data?.attributes?.alternativeText ?? '';
+const safeMediaThumbUrl = (media) => {
+  const formats = media?.data?.attributes?.formats;
+  const url = formats?.thumbnail?.url || formats?.small?.url || media?.data?.attributes?.url;
+  return url ? `${process.env.REACT_APP_strapiURL}${url}` : null;
+};
+
+// Normalizes a coin-collections record into a shape that matches your existing CoinSort assumptions
+const normalizeCoinCollection = (cc) => {
+  const a = cc?.attributes ?? {};
+
+  // coin-sort expects "from_date" for sorting/filtering; coin-collections uses from_year
+  const fromYear = a.from_year ?? null;
+
+  // SimplyMappedCoin historically expects strings for match-type filters/sorts
+  const materialStr = safeRelName(a.material) ?? (a.material?.data?.attributes?.name ?? null);
+  const issuingStr = safeRelName(a.issuing_authority) ?? null;
+  const govStr = safeRelName(a.governing_power, ['governing_power', 'name', 'title']) ?? null;
+
+  // coin-sort expects obverse_file with formats.thumbnail.url (relative url)
+  // We'll provide a compatible structure + a direct thumbnail string for easier use.
+  const obvFormats = safeMediaFormats(a.obverse_image);
+  const obvThumbRelative = obvFormats?.thumbnail?.url || obvFormats?.small?.url || a.obverse_image?.data?.attributes?.url || null;
+
+  return {
+    id: cc.id,
+    attributes: {
+      // core fields used by positioning/sorting/filtering
+      diameter: a.diameter ?? null,
+      from_date: fromYear,
+      material: materialStr,
+      issuing_authority: issuingStr,
+      governing_power: govStr,
+      // keep other helpful fields if your details UI uses them
+      to_date: a.to_year ?? null,
+
+      // media: legacy-compatible nesting + direct src convenience
+      obverse_file: {
+        data: obvThumbRelative
+          ? {
+              attributes: {
+                formats: obvFormats,
+                alternativeText: safeMediaAlt(a.obverse_image),
+              },
+            }
+          : null,
+      },
+
+      // Convenience: direct thumbnail url for rendering
+      obverse_thumb_src: safeMediaThumbUrl(a.obverse_image),
+    },
+  };
+};
+
+const hasThumb = (coin) => {
+  // Prefer the convenience field (more reliable), fall back to legacy format path
+  return Boolean(
+    coin?.attributes?.obverse_thumb_src ||
+      coin?.attributes?.obverse_file?.data?.attributes?.formats?.thumbnail?.url
+  );
+};
+
+// ─────────────────────────────────────────────────────────────
+// Coin renderer (pile)
+// ─────────────────────────────────────────────────────────────
+const Coin = ({ id, x, y, display, dimensions, coinMetaData, setDraggedCoinId }) => {
+
+  const diameter = coinMetaData?.attributes?.diameter ?? 10; // fallback so it renders
+  // ADJUST HERE FOR SCALING. IN THIS DATA SOME COINS ARE VERY SMALL RELATIVELY
+  const thumbnail_scale = 1.5;
+  const MIN_RENDER_SIZE = 32;
+  const MAX_RENDER_SIZE = 90;
+
+  const MIN_DIAM = 8;
+  const MAX_DIAM = 45;
+
+  const clamped = Math.min(Math.max(diameter, MIN_DIAM), MAX_DIAM);
+
+  const normalized = (clamped - MIN_DIAM) / (MAX_DIAM - MIN_DIAM);
+
+  const width = (MIN_RENDER_SIZE + normalized * (MAX_RENDER_SIZE - MIN_RENDER_SIZE)) * thumbnail_scale;
+
+  let px = (x ?? 0) * (dimensions?.width ?? 0);
+  let py = (y ?? 0) * (dimensions?.height ?? 0);
+
+  if ((px + width) > (dimensions?.width ?? 0)) px = (dimensions?.width ?? 0) - width;
+  if ((py + width) > (dimensions?.height ?? 0)) py = (dimensions?.height ?? 0) - width;
+  if (px < 0) px = 0;
+  if (py < 0) py = 0;
+
+  if (!display) {
+    px = -10000;
+    py = -10000;
+  }
+
+  const src =
+    coinMetaData?.attributes?.obverse_thumb_src ||
+    (coinMetaData?.attributes?.obverse_file?.data?.attributes?.formats?.thumbnail?.url
+      ? `${process.env.REACT_APP_strapiURL}${coinMetaData.attributes.obverse_file.data.attributes.formats.thumbnail.url}`
+      : null);
+
+  if (!src) return null;
+
+  return (
+    <div
+      className="coin-sort-pile-coin"
+      style={{ top: `${py}px`, left: `${px}px` }}
+      draggable
+      onDragStart={() => setDraggedCoinId(id)}
+    >
+      <img
+        id={`coin-sort-${id}`}
+        className="coin-sort-pile-coin-image"
+        src={src}
+        alt={coinMetaData?.attributes?.obverse_file?.data?.attributes?.alternativeText ?? ''}
+        width={width}
+      />
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────
+// Positioning / sorting / filtering (mostly unchanged)
+// ─────────────────────────────────────────────────────────────
+function ComputeCoinPos(coins, sort_selection, then_by_selection, filter_selection, with_selection, of_kind_selection, governingPowers) {
+  if (!Array.isArray(coins)) return null;
+
+  let coins_pos = new Map(
+    coins.map((coin, index) => [
+      coin.id,
+      {
+        index,
+        ...DefaultCoinPileGraphingStategy(coin),
+        display: true,
+      },
+    ])
+  );
+
+  if (sort_selection !== sort_selections[0]) {
+    const tmp_coins = coins.map((coin, index) => SimplyMappedCoin(coin, index));
+
+    let key;
+    let query_selection;
+    let is_match_type = true;
+
+    switch (sort_selection) {
+      case sort_selections[1]:
+        key = 'from_date';
+        query_selection = of_kind_from_date_query_relation;
+        is_match_type = false;
+        break;
+      case sort_selections[2]:
+        key = 'material';
+        query_selection = of_kind_material_selections;
+        is_match_type = true;
+        break;
+      case sort_selections[3]:
+        key = 'issuing_authority';
+        query_selection = of_kind_issuing_authority_selections;
+        is_match_type = true;
+        break;
+      case sort_selections[4]:
+        key = 'governing_power';
+        query_selection = governingPowers ?? ['None'];
+        is_match_type = true;
+        break;
+      case sort_selections[5]:
+        key = 'size';
+        query_selection = of_kind_size_query_relation;
+        is_match_type = false;
+        break;
+      default:
+        console.error('No sort selection option', sort_selection);
+        query_selection = [];
+        break;
+    }
+
+    let coin_piles = [];
+    for (let index = 0; index < query_selection.length; index++) {
+      const query = query_selection[index];
+      if (index === 0) continue;
+
+      const coin_pile = [];
+      for (let i = 0; i < tmp_coins.length; i++) {
+        const v = tmp_coins[i]?.[key];
+
+        if (is_match_type) {
+          if (typeof v === 'string' && v.toLowerCase().includes(String(query).toLowerCase())) {
+            coin_pile.push(tmp_coins[i]);
+          }
+        } else {
+          if (typeof v === 'number' && v >= query.gte && v <= query.lte) {
+            coin_pile.push(tmp_coins[i]);
+          }
+        }
+      }
+      coin_piles.push(coin_pile);
+    }
+
+    coin_piles = coin_piles.filter((arr) => arr.length !== 0);
+    let pile_locations = CoinPileLocations(coin_piles.length);
+
+    if (then_by_selection !== then_by_selections[0]) {
+      key = undefined;
+      query_selection = undefined;
+      is_match_type = true;
+
+      switch (then_by_selection) {
+        case then_by_selections[1]:
+          key = 'from_date';
+          query_selection = of_kind_from_date_query_relation;
+          is_match_type = false;
+          break;
+        case then_by_selections[2]:
+          key = 'material';
+          query_selection = of_kind_material_selections;
+          is_match_type = true;
+          break;
+        case then_by_selections[3]:
+          key = 'issuing_authority';
+          query_selection = of_kind_issuing_authority_selections;
+          is_match_type = true;
+          break;
+        case then_by_selections[4]:
+          key = 'governing_power';
+          query_selection = governingPowers ?? ['None'];
+          is_match_type = true;
+          break;
+        case then_by_selections[5]:
+          key = 'size';
+          query_selection = of_kind_size_query_relation;
+          is_match_type = false;
+          break;
+        default:
+          console.error('No sort selection option', then_by_selection);
+          query_selection = [];
+      }
+
+      const new_pile_locations = [];
+      const new_coin_piles = [];
+
+      for (let i = 0; i < pile_locations.length; i++) {
+        const sort_by_coin_pile = coin_piles[i];
+        const then_by_new_coin_piles = [];
+
+        for (let j = 0; j < query_selection.length; j++) {
+          if (j === 0) continue;
+          const query = query_selection[j];
+
+          const new_coin_pile = [];
+          for (let k = 0; k < sort_by_coin_pile.length; k++) {
+            const coin = sort_by_coin_pile[k];
+            const v = coin?.[key];
+
+            if (is_match_type) {
+              if (typeof v === 'string' && v.toLowerCase().includes(String(query).toLowerCase())) {
+                new_coin_pile.push(coin);
+              }
+            } else {
+              if (typeof v === 'number' && v >= query.gte && v <= query.lte) {
+                new_coin_pile.push(coin);
+              }
+            }
+          }
+          then_by_new_coin_piles.push(new_coin_pile);
+        }
+
+        const distance_from_center = 0.04;
+        const center = pile_locations[i];
+        const degrees_between_pile = 360 / Math.max(1, then_by_new_coin_piles.length);
+
+        for (let j = 0; j < then_by_new_coin_piles.length; j++) {
+          new_pile_locations.push({
+            x: distance_from_center * Math.cos(degToRad(degrees_between_pile * j)) + center.x,
+            y: distance_from_center * Math.sin(degToRad(degrees_between_pile * j)) + center.y,
+          });
+        }
+
+        new_coin_piles.push(then_by_new_coin_piles);
+      }
+
+      coin_piles = new_coin_piles.flat();
+      pile_locations = new_pile_locations.flat();
+    }
+
+    let new_coin_pos = new Map();
+    const coin_deviation_in_pile = then_by_selection === then_by_selections[0] ? 0.15 : 0.075;
+
+    for (let i = 0; i < pile_locations.length; i++) {
+      const more_mapped_coins = coin_piles[i].map((coin) => [
+        coin.id,
+        {
+          index: coin.props_index,
+          x: GaussianDeviationOnValue(pile_locations[i].x, coin_deviation_in_pile),
+          y: GaussianDeviationOnValue(pile_locations[i].y, coin_deviation_in_pile),
+          display: true,
+        },
+      ]);
+
+      new_coin_pos = new Map([...new_coin_pos, ...more_mapped_coins]);
+    }
+
+    coins_pos = new_coin_pos;
+  }
+
+  if (filter_selection !== filter_selections[0] && with_selection !== with_selections[0]) {
+    const filter_include = filter_selections_query_relation[filter_selections.findIndex((str) => str === filter_selection)];
+
+    let coin_key;
+    let query = undefined;
+
+    switch (with_selection) {
+      case with_selections[1]:
+        coin_key = 'from_date';
+        query = of_kind_from_date_query_relation[of_kind_from_date_selections.findIndex((e) => e === of_kind_selection)];
+        break;
+      case with_selections[2]:
+        coin_key = 'material';
+        break;
+      case with_selections[3]:
+        coin_key = 'issuing_authority';
+        break;
+      case with_selections[4]:
+        coin_key = 'governing_power';
+        break;
+      case with_selections[5]:
+        coin_key = 'size';
+        query = of_kind_size_query_relation[of_kind_size_selections.findIndex((e) => e === of_kind_selection)];
+        break;
+      default:
+        console.error('No sort selection option', with_selection);
+        coin_key = undefined;
+    }
+
+    const new_coins_pos =
+      coins_pos == null
+        ? null
+        : new Map(
+            Array.from(coins_pos).map((coin_pos) => {
+              const coin = SimplyMappedCoin(coins[coin_pos[1].index], coin_pos[1].index);
+              let does_include = filter_include;
+
+              try {
+                if (query == null) {
+                  does_include =
+                    coin?.[coin_key]?.toLowerCase?.()?.includes?.(String(of_kind_selection).toLowerCase()) ?? filter_include;
+                } else {
+                  does_include = coin?.[coin_key] >= query.gte && coin?.[coin_key] <= query.lte;
+                }
+              } catch (err) {}
+
+              if ((filter_include && !does_include) || (!filter_include && does_include)) coin_pos[1].display = false;
+              else coin_pos[1].display = true;
+
+              return coin_pos;
+            })
+          );
+
+    coins_pos = new_coins_pos;
+  }
+
+  return coins_pos;
+}
+
+// ─────────────────────────────────────────────────────────────
+// CoinPile component
+// ─────────────────────────────────────────────────────────────
+const CoinPile = (props) => {
+  const coin_wrapper_ref = useRef(null);
+  const [coins_pos, set_coins_pos] = useState(undefined);
+  const [dimensions, set_dimensions] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    set_coins_pos(
+      ComputeCoinPos(
+        props.coins,
+        props.sortSelection,
+        props.thenBySelection,
+        props.filterSelection,
+        props.withSelection,
+        props.ofKindSelection,
+        props.governingPowers
+      )
+    );
+  }, [
+    props.coins,
+    props.sortSelection,
+    props.thenBySelection,
+    props.filterSelection,
+    props.withSelection,
+    props.ofKindSelection,
+    props.governingPowers,
+  ]);
+
+  useEffect(() => {
+    const el = coin_wrapper_ref.current;
+    if (!el) return;
+
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      set_dimensions({ width: Math.round(rect.width), height: Math.round(rect.height) });
+    };
+
+    update();
+
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      ro.disconnect();
+    };
+  }, []);
+
+  return (
+    <div className="coin-sort-pile-wrapper" ref={coin_wrapper_ref}>
+      <div className="coin-sort-pile">
+        {props.coins?.map((coin) => (
+          <Coin
+            id={coin.id}
+            key={coin.id}
+            coinMetaData={coin}
+            dimensions={dimensions}
+            display={coins_pos?.get(coin.id)?.display ?? true}
+            x={coins_pos?.get(coin.id)?.x}
+            y={coins_pos?.get(coin.id)?.y}
+            setDraggedCoinId={props.setDraggedCoinId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────
+// CoinSort2 main component
+// ─────────────────────────────────────────────────────────────
+const CoinSort2 = () => {
+  const [is_loading, set_is_loading] = useState(true);
+
+  const [coins, set_coins] = useState(undefined);
+  const [has_fetched_coins, set_has_fetched_coins] = useState(false);
+
+  const [scale_all] = useState(false);
+  const [rotate_all] = useState(false);
+  const ShowScaleAndRotate = () => {};
+
+  const [dragged_coin_id, set_dragged_coin_id] = useState(undefined);
+  const SetDraggedCoinId = (coin_id) => set_dragged_coin_id(coin_id);
+
+  const [sort_selection, set_sort_selection] = useState(sort_selections[0]);
+  const [then_by_selection, set_then_by_selection] = useState(then_by_selections[0]);
+  const [filter_selection, set_filter_selection] = useState(filter_selections[0]);
+  const [with_selection, set_with_selection] = useState(with_selections[0]);
+  const [of_kind_selection, set_of_kind_selection] = useState(of_kind_no_selections[0]);
+  const [of_kind_selections, set_of_kind_selections] = useState(of_kind_no_selections);
+
+  // Governing powers list must be state so React re-renders when it arrives
+  const [governingPowers, setGoverningPowers] = useState(['None']);
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const { data } = await axios.get(`${process.env.REACT_APP_strapiURL}/api/governing-powers`);
+        const arr =
+          data?.data?.map(({ attributes }) => attributes?.governing_power).filter(Boolean) ?? [];
+        if (mounted) setGoverningPowers(['None', ...arr]);
+      } catch (err) {
+        if (mounted) setGoverningPowers(['None']);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  // ✅ Fetch from coin-collections (new source)
+  useEffect(() => {
+    const FetchCollections = async () => {
+      const res = await coinCollectionsRequest.fetchAllForCoinSort?.();
+      const rows = Array.isArray(res?.data?.data) ? res.data.data : [];
+      const normalized = rows.map(normalizeCoinCollection).filter(hasThumb);
+
+      set_coins(normalized);
+      set_has_fetched_coins(true);
+    };
+
+    if (!has_fetched_coins) FetchCollections().catch((e) => console.error(e));
+  }, [has_fetched_coins]);
+
+  // Tooltips/config (keep existing coin-sort singleton)
+  const [coinSortData, setCoinSortData] = useState([]);
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const result = await coinSortRequest.coinSortFind();
+        if (!mounted) return;
+        setCoinSortData(result?.data?.data?.attributes ?? {});
+      } finally {
+        if (mounted) set_is_loading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  // With → Of Kind selections
+  useEffect(() => {
+    set_of_kind_selections(() => {
+      switch (with_selection) {
+        case 'None':
+          set_of_kind_selection(of_kind_no_selections[0]);
+          return of_kind_no_selections;
+        case 'Minting Date':
+          set_of_kind_selection(of_kind_from_date_selections[0]);
+          return of_kind_from_date_selections;
+        case 'Material':
+          set_of_kind_selection(of_kind_material_selections[0]);
+          return of_kind_material_selections;
+        case 'Issuing Authority':
+          set_of_kind_selection(of_kind_issuing_authority_selections[0]);
+          return of_kind_issuing_authority_selections;
+        case 'Governing Power':
+          set_of_kind_selection(governingPowers[0] ?? 'None');
+          return governingPowers;
+        case 'Size':
+          set_of_kind_selection(of_kind_size_selections[0]);
+          return of_kind_size_selections;
+        default:
+          set_of_kind_selection(of_kind_no_selections[0]);
+          return of_kind_no_selections;
+      }
+    });
+  }, [with_selection, governingPowers]);
+
+  // Clear buttons
+  const [show_sort_clear_button, set_show_sort_clear_button] = useState(false);
+  useEffect(() => {
+    set_show_sort_clear_button(sort_selection !== sort_selections[0] || then_by_selection !== then_by_selections[0]);
+  }, [sort_selection, then_by_selection]);
+
+  const [show_filter_clear_button, set_show_filter_clear_button] = useState(false);
+  useEffect(() => {
+    set_show_filter_clear_button(
+      filter_selection !== filter_selections[0] ||
+        with_selection !== with_selections[0] ||
+        of_kind_selection !== of_kind_selections[0]
+    );
+  }, [filter_selection, with_selection, of_kind_selection, of_kind_selections]);
+
+  if (is_loading) return <LoadingPage />;
+
+  return (
+    <>
+      <NoFeedBackIcon formfor="coinpile" />
+      <div id="coin-pile-page">
+        <center>
+          <h1>Coins in a Pile</h1>
+          <h3 className="mb-5 pb-5">Explore the SYRIOS Collection</h3>
+        </center>
+
+        <div style={{ width: '50%', marginLeft: '25%' }}>
+          <ol>
+            <li className="story-text mb-5">
+              Drag coins from the pile on the edges into this center area to study them more closely.
+            </li>
+            <li className="story-text mb-5">Click on a coin to see complete details.</li>
+            <li className="story-text mb-5">
+              Use the tools, below, to arrange, sort, and filter the coins to identify the patterns and discover the hidden
+              stories that connect them to each other and to us.
+            </li>
+          </ol>
+        </div>
+
+        <div id="coin-sort-wrapper">
+          <div className="navbar-spacer" />
+
+          <CoinPile
+            coins={coins}
+            setDraggedCoinId={SetDraggedCoinId}
+            sortSelection={sort_selection}
+            thenBySelection={then_by_selection}
+            filterSelection={filter_selection}
+            withSelection={with_selection}
+            ofKindSelection={of_kind_selection}
+            governingPowers={governingPowers}
+          />
+
+          <div id="coin-sort-options-wrapper">
+            <div id="coin-sort-options">
+              <CoinSortDropDown
+                title="Sort:"
+                selections={sort_selections}
+                state={sort_selection}
+                setState={set_sort_selection}
+                toolTips={coinSortData?.sort_tool_tips}
+                showClear={show_sort_clear_button}
+                clearTitle="Clear Sort"
+                clear={() => {
+                  set_sort_selection(sort_selections[0]);
+                  set_then_by_selection(then_by_selections[0]);
+                  set_show_sort_clear_button(false);
+                }}
+              />
+
+              <CoinSortDropDown
+                title="Then by:"
+                selections={then_by_selections}
+                state={then_by_selection}
+                setState={set_then_by_selection}
+              />
+
+              <div className="coin-sort-menu-vr">
+                <div className="coin-sort-menu-vr-content" />
+              </div>
+
+              <CoinSortDropDown
+                title="Filter:"
+                selections={filter_selections}
+                state={filter_selection}
+                setState={set_filter_selection}
+                toolTips={coinSortData?.filter_tool_tips}
+                showClear={show_filter_clear_button}
+                clearTitle="Clear Filter"
+                clear={() => {
+                  set_filter_selection(filter_selections[0]);
+                  set_with_selection(with_selections[0]);
+                  set_of_kind_selection(of_kind_selections[0]);
+                  set_show_filter_clear_button(false);
+                }}
+              />
+
+              <CoinSortDropDown title="With:" selections={with_selections} state={with_selection} setState={set_with_selection} />
+
+              <CoinSortDropDown
+                title="Of Kind:"
+                selections={of_kind_selections}
+                state={of_kind_selection}
+                setState={set_of_kind_selection}
+              />
+            </div>
+          </div>
+
+          <CoinGrid
+            coinToAdd={dragged_coin_id}
+            rotateAll={rotate_all}
+            scaleAll={scale_all}
+            showScaleAndRotate={ShowScaleAndRotate}
+          />
+
+          <div style={{ zIndex: -100, position: 'fixed', width: '100vw', height: '100vh', top: 0, left: 0 }} />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CoinSort2;

--- a/src/pages/Evidence/CoinSort/CoinSortCoinGrid.js
+++ b/src/pages/Evidence/CoinSort/CoinSortCoinGrid.js
@@ -78,11 +78,52 @@ export const CoinScaleAndFlip = (props) => {
     }
   }, [props.rotate]);
 
+  /* deprecated scale code 
   useEffect(() => {
     if ((props.scale && !is_img_scaled) || (!props.scale && is_img_scaled)) {
       ScaleCoin();
     }
   }, [props.scale]); // IGNORE the warning. This is so that scale all can unscale just 1 or 2 coins if needed.
+  */
+
+  // Sync local scale state with parent "scale all" control.
+  // 
+  // We intentionally do NOT call ScaleCoin() here because:
+  // 1) ScaleCoin mutates internal state (is_img_scaled),
+  // 2) Calling it inside useEffect would require adding it as a dependency,
+  // 3) That would cause unnecessary re-renders or potential loops.
+  //
+  // Instead, we replicate the scale logic inline so that this effect
+  // responds deterministically only to `props.scale` changes.
+  // 
+  // This keeps React Hook dependency rules satisfied and prevents
+  // infinite toggling when `is_img_scaled` updates.
+  useEffect(() => {
+    if (props.scale && !is_img_scaled) {
+      // scale up
+      set_dotted_circle_height('80%');
+
+      const box_percent = 100;
+      const box_height_mm = 62.5;
+      let height_of_coin_percent =
+        (box_percent / box_height_mm) * props.coinMetaData.diameter;
+
+      if (!height_of_coin_percent) {
+        height_of_coin_percent = 5;
+      }
+
+      set_img_height(`${height_of_coin_percent}%`);
+      set_is_img_scaled(true);
+    }
+
+    if (!props.scale && is_img_scaled) {
+      // scale down
+      set_dotted_circle_height('0%');
+      set_img_height('100%');
+      set_is_img_scaled(false);
+    }
+  }, [props.scale, props.coinMetaData.diameter, is_img_scaled]);
+
 
   const renderTooltipScale = (props) => (
     <Tooltip id="button-tooltip" {...props}>

--- a/src/pages/Evidence/CoinSort/CoinUtils.js
+++ b/src/pages/Evidence/CoinSort/CoinUtils.js
@@ -37,6 +37,8 @@ export function DefaultCoinPileGraphingStategy(coin) {
   }
 
   // This function converts the data we recieve from strapi into a more easily parsed data format
+  // older version
+  /*
 export function SimplyMappedCoin(coin, index) {
     return {
       props_index: index,
@@ -48,7 +50,38 @@ export function SimplyMappedCoin(coin, index) {
       size: coin.attributes.diameter
     };
   }
+*/
+// This function converts the data we recieve from strapi into a more easily parsed data format
+export function SimplyMappedCoin(coin, index) {
+  const a = coin?.attributes ?? {};
 
+  // Works for:
+  // 1) old coins API shape: governing_power is a relation { data: { attributes: { governing_power } } }
+  // 2) CoinSort2 normalized shape: governing_power is already a string
+  const governing_power =
+    typeof a.governing_power === 'string'
+      ? a.governing_power
+      : a.governing_power?.data?.attributes?.governing_power;
+
+  // Same idea for material / issuing authority if your CoinSort2 adapter returns strings
+  const material =
+    typeof a.material === 'string' ? a.material : a.material?.data?.attributes?.name;
+
+  const issuing_authority =
+    typeof a.issuing_authority === 'string'
+      ? a.issuing_authority
+      : a.issuing_authority?.data?.attributes?.name;
+
+  return {
+    props_index: index,
+    id: coin.id,
+    from_date: a.from_date ?? a.from_year ?? null,
+    material,
+    issuing_authority,
+    governing_power,
+    size: a.diameter ?? null,
+  };
+}
   
 // This evenly distrubutes the pile locations along the left, bottom, and right side of the CoinPile div.
 export function CoinPileLocations(arr_length) {


### PR DESCRIPTION
- Adds CoinSort2 page using coin-collections as the primary data source
- Normalizes coin-collections records into CoinSort-compatible structure
- Filters out records without obverse thumbnails
- Implements diameter normalization scaling so very small coins render visibly
- Preserves existing CoinSort tooltips/config endpoint
- Leaves original CoinSort intact for comparison
- Minor QOL fixes in CoinSort code